### PR TITLE
chore: add new workflow to verify if label exist in pr

### DIFF
--- a/.github/workflows/require_label.yml
+++ b/.github/workflows/require_label.yml
@@ -1,0 +1,19 @@
+name: Require label
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, labeled, unlabeled]
+
+jobs:
+  check-label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if PR has label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels;
+            if (labels.length === 0) {
+              core.setFailed("PR must have at least one label");
+            }


### PR DESCRIPTION
## Description

Briefly describe the changes introduced by this pull request.

add a workflow to verify if a label exists in pull requests

## Type of Change

Check the relevant options.

- [ ] Bug fix
- [ ] New functionality
- [ ] Performance improvement
- [x] other

## Verification

- [x] I checked for conflicts with the target branch

## Additional comments

Please provide any additional comments or relevant information.