### PR TITLE
chore: update enabled linters in .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,12 +11,9 @@ issues:
 
 linters:
   enable:
-    - errcheck
-    - govet
     - staticcheck
     - gosimple
     - unused
-    - ineffassign
     - typecheck
     - gofmt
     - goimports


### PR DESCRIPTION
Removed 'errcheck', 'govet', and 'ineffassign' from the enabled linters.

## Description

Briefly describe the changes introduced by this pull request.

## Type of Change

Check the relevant options.

- [ ] Bug fix
- [ ] New functionality
- [ ] Performance improvement
- [ ] other

## Verification

- [ ] I checked for conflicts with the target branch

## Additional comments

Please provide any additional comments or relevant information.